### PR TITLE
chore: add cabal-cache to github action

### DIFF
--- a/.github/workflows/runhaskell.yml
+++ b/.github/workflows/runhaskell.yml
@@ -7,13 +7,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Cache ~/.cabal/packages, ~/.cabal/store and dist-newstyle
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cabal/packages
             ~/.cabal/store
             dist-newstyle
-          key: ${{ runner.os }}-${{ matrix.ghc }}
+          key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('**/*.cabal', '**/cabal.project', '**/cabal.project.freeze') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.ghc }}-
       - uses: haskell/actions/setup@v2
         with:
           ghc-version: '9.2'

--- a/.github/workflows/runhaskell.yml
+++ b/.github/workflows/runhaskell.yml
@@ -6,6 +6,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Cache ~/.cabal/packages, ~/.cabal/store and dist-newstyle
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cabal/packages
+            ~/.cabal/store
+            dist-newstyle
+          key: ${{ runner.os }}-${{ matrix.ghc }}
       - uses: haskell/actions/setup@v2
         with:
           ghc-version: '9.2'


### PR DESCRIPTION
Installing few dependencies takes over 2 minutes.

This change introduce cabal-cache to github actions. See https://github.com/action-works/cabal-cache